### PR TITLE
Run karma tests only on watch or tdd

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,12 @@ var gutils = require('gulp-util');
 
 var task = elixir.Task;
 
+function isTddOrWatchTask() {
+    return gutils.env._.indexOf('watch') > -1 || gutils.env._.indexOf('tdd') > -1;
+}
+
 elixir.extend('karma', function(args) {
-    if (! _.contains(['watch', 'tdd'], gutils.env._)) return;
+    if (! isTddOrWatchTask()) return;
 
     var defaults = {
         configFile: process.cwd()+'/karma.conf.js',
@@ -21,10 +25,9 @@ elixir.extend('karma', function(args) {
     var isStarted = false;
 
     new task('karma', function() {
-        if( ! isStarted && (_.contains(['watch', 'tdd'], gutils.env._))) {
+        if( ! isStarted) {
             karma.start(options);
             isStarted = true;
         }
     }).watch(options.jsDir, 'tdd');
 });
-

--- a/index.js
+++ b/index.js
@@ -2,10 +2,13 @@ var gulp = require('gulp');
 var elixir = require('laravel-elixir');
 var karma = require('karma').server;
 var _ = require('underscore');
+var gutils = require('gulp-util');
 
 var task = elixir.Task;
 
 elixir.extend('karma', function(args) {
+    if (! _.contains(['watch', 'tdd'], gutils.env._)) return;
+
     var defaults = {
         configFile: process.cwd()+'/karma.conf.js',
         jsDir: ['resources/assets/js/**/*.js', 'resources/assets/coffee/**/*.coffee']
@@ -16,11 +19,10 @@ elixir.extend('karma', function(args) {
     var isStarted = false;
 
     new task('karma', function() {
-        if( ! isStarted) {
+        if( ! isStarted && (_.contains(['watch', 'tdd'], gutils.env._))) {
             karma.start(options);
             isStarted = true;
         }
     }).watch(options.jsDir, 'tdd');
-
 });
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@ elixir.extend('karma', function(args) {
 
     var defaults = {
         configFile: process.cwd()+'/karma.conf.js',
-        jsDir: ['resources/assets/js/**/*.js', 'resources/assets/coffee/**/*.coffee']
+        jsDir: ['resources/assets/js/**/*.js', 'resources/assets/coffee/**/*.coffee'],
+        autoWatch: true,
+        singleRun: false
     };
 
     var options = _.extend(defaults, args);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "karma": "^0.13",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "gulp-util": "^3.0.6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
There is a known issue with karma, where it prevents the main process from stopping.

If you try `gulp` or  `gulp --production` gulp won't stop when tasks are finished because of some
karma's timeouts not being cleaned, not sure if the issue has been fixed, but, as of now, it's not working for me.

So, I thought we should limit running karma tests to "watch" and "tdd" tasks to prevent problems when running gulp on a production environment.
