### PR TITLE
Deleted exclamation mark

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function isTddOrWatchTask() {
 }
 
 elixir.extend('karma', function(args) {
-    if (! isTddOrWatchTask()) return;
+    if (isTddOrWatchTask()) return;
 
     var defaults = {
         configFile: process.cwd() + '/karma.conf.js',


### PR DESCRIPTION
Hello
In Issues I comment the situation, I didn't know why karma is now working.

I found  by default gutils.env._.indexOf()  = -1 then 
   gutils.env._.indexOf('watch') > -1 || gutils.env._.indexOf('tdd') > -1
is false 
then ! gutils.env._.indexOf('watch') > -1 || gutils.env._.indexOf('tdd') > -1
is true
and always ends the code.
